### PR TITLE
Fix selectors

### DIFF
--- a/daily_hn.py
+++ b/daily_hn.py
@@ -10,6 +10,7 @@ news.ycombinator.com (Hacker News)
 """
 
 import curses
+import sys
 import webbrowser
 from argparse import ArgumentParser
 
@@ -81,7 +82,7 @@ class Stories:
         titles = cls._get_titles(soup)
         scores = cls._get_scores(soup)
 
-        return [
+        stories = [
             {
                 "headline": title.get_text(),
                 "link": title["href"]
@@ -91,6 +92,15 @@ class Stories:
             }
             for title, score in zip(titles, scores)
         ]
+
+        if not stories:
+            sys.exit(
+                "The list of stories is empty. Please ensure the following values are correct:"
+                f"\nSite url: {cls.best_stories_url}"
+                f"\nTitle selector: {cls.titles_selector}"
+                f"\nScore selector: {cls.score_selector}"
+            )
+        return stories
 
     @classmethod
     def print_articles(cls, stories: list[dict] = None):

--- a/daily_hn.py
+++ b/daily_hn.py
@@ -36,7 +36,7 @@ class Stories:
     base_url: str = "https://news.ycombinator.com/"
     best_stories_url: str = f"{base_url}best"
     score_selector: str = ".score"
-    titles_selector: str = ".titlelink"
+    titles_selector: str = ".titleline a"
 
     @classmethod
     def _get_soup(cls, link: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "daily_hn"
-version = "0.1.3"
+version = "0.2.0"
 readme="README.md"
 description = "A command line tool for displaying and opening links to the current best stories from news.ycombinator.com (Hacker News)"
 authors = ["Rolv-Apneseth <rolv.apneseth@gmail.com>"]


### PR DESCRIPTION
Updated selectors used for titles when parsing the hacker news site as they changed them, and added a helpful error message if the issue occurs again in the future.