### PR TITLE
fix: adjusted title specificity so that only the title is grabbed and…

### DIFF
--- a/daily_hn.py
+++ b/daily_hn.py
@@ -37,7 +37,7 @@ class Stories:
     base_url: str = "https://news.ycombinator.com/"
     best_stories_url: str = f"{base_url}best"
     score_selector: str = ".score"
-    titles_selector: str = ".titleline a"
+    titles_selector: str = ".titleline > a"
 
     @classmethod
     def _get_soup(cls, link: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "daily_hn"
-version = "0.1.4"
+version = "0.1.5"
 readme="README.md"
 description = "A command line tool for displaying and opening links to the current best stories from news.ycombinator.com (Hacker News)"
 authors = ["Rolv-Apneseth <rolv.apneseth@gmail.com>"]


### PR DESCRIPTION
… not the source of the article as well

This quick fix is done by setting the selector to point to anchor tags that are direct children of `.titleline` instead of any children.